### PR TITLE
ByteEx Utility

### DIFF
--- a/Backend.Fx.sln.DotSettings
+++ b/Backend.Fx.sln.DotSettings
@@ -1,4 +1,8 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=csprojs/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Gibi/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Kibi/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mebi/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Myget/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=nupkg/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=nupkg/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tebi/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Backend.Fx.Tests/Util/ByteExTests.cs
+++ b/src/Backend.Fx.Tests/Util/ByteExTests.cs
@@ -1,0 +1,88 @@
+using Backend.Fx.Util;
+using Xunit;
+
+namespace Backend.Fx.Tests.Util;
+
+public class ByteExTests
+{
+    [Theory]
+    [InlineData(1, 1_000)]
+    [InlineData(2, 2_000)]
+    [InlineData(0, 0)]
+    public void KbReturnsDecimalKilobytes(int input, int expected)
+        => Assert.Equal(expected, input.KB());
+
+    [Theory]
+    [InlineData(1, 1_000_000)]
+    [InlineData(2, 2_000_000)]
+    public void MbReturnsDecimalMegabytes(int input, int expected)
+        => Assert.Equal(expected, input.MB());
+
+    [Theory]
+    [InlineData(1, 1_000_000_000)]
+    public void GbReturnsDecimalGigabytes(int input, int expected)
+        => Assert.Equal(expected, input.GB());
+
+    [Theory]
+    [InlineData(1, 1_000_000_000_000L)]
+    [InlineData(2, 2_000_000_000_000L)]
+    public void TbReturnsDecimalTerabytes(int input, long expected)
+        => Assert.Equal(expected, input.TB());
+
+    [Theory]
+    [InlineData(1, 1_024)]
+    [InlineData(2, 2_048)]
+    [InlineData(0, 0)]
+    public void KiBReturnsBinaryKibibytes(int input, int expected)
+        => Assert.Equal(expected, input.KiB());
+
+    [Theory]
+    [InlineData(1, 1_048_576)]
+    [InlineData(2, 2_097_152)]
+    public void MiBReturnsBinaryMebibytes(int input, int expected)
+        => Assert.Equal(expected, input.MiB());
+
+    [Theory]
+    [InlineData(1, 1_073_741_824)]
+    public void GiBReturnsBinaryGibibytes(int input, int expected)
+        => Assert.Equal(expected, input.GiB());
+
+    [Theory]
+    [InlineData(1, 1_099_511_627_776L)]
+    [InlineData(2, 2_199_023_255_552L)]
+    public void TiBReturnsBinaryTebibytes(int input, long expected)
+        => Assert.Equal(expected, input.TiB());
+
+    [Theory]
+    [InlineData(0UL, "0 B")]
+    [InlineData(500UL, "500 B")]
+    // 1000 is the (decimal) threshold, but the switch only matches values strictly greater than it
+    [InlineData(1000UL, "1000 B")]
+    // values are scaled by the binary unit (1024), so 1024 bytes is exactly 1 KB
+    [InlineData(1024UL, "1 KB")]
+    [InlineData(2048UL, "2 KB")]
+    [InlineData(1_048_576UL, "1 MB")]
+    [InlineData(1_073_741_824UL, "1 GB")]
+    [InlineData(1_099_511_627_776UL, "1 TB")]
+    public void ToHumanReadableFormatsUlong(ulong size, string expected)
+        => Assert.Equal(expected, size.ToHumanReadable());
+
+    [Fact]
+    public void ToHumanReadableRoundsToOneDecimalPlace()
+    {
+        Assert.Equal("1 KB", 1024.ToHumanReadable());
+        Assert.Equal("1.5 KB", 1555.ToHumanReadable());
+        Assert.Equal("1.6 KB", 1600.ToHumanReadable());
+        Assert.Equal("1.5 MB", 1_600_000.ToHumanReadable());
+    }
+
+    [Fact]
+    public void ToHumanReadableDelegatesForAllIntegerOverloads()
+    {
+        Assert.Equal("2 KB", ((short)2048).ToHumanReadable());
+        Assert.Equal("2 KB", ((ushort)2048).ToHumanReadable());
+        Assert.Equal("1 MB", 1_048_576.ToHumanReadable());
+        Assert.Equal("1 GB", 1_073_741_824u.ToHumanReadable());
+        Assert.Equal("1 TB", 1_099_511_627_776L.ToHumanReadable());
+    }
+}

--- a/src/Backend.Fx/Util/ByteEx.cs
+++ b/src/Backend.Fx/Util/ByteEx.cs
@@ -1,0 +1,73 @@
+using System;
+using JetBrains.Annotations;
+
+namespace Backend.Fx.Util;
+
+[PublicAPI]
+public static class BytesEx
+{
+    private const int OneKiloByte = 1000;
+    private const int OneMegaByte = 1000 * 1000;
+    private const int OneGigaByte = 1000 * 1000 * 1000;
+    private const long OneTeraByte = 1000L * 1000 * 1000 * 1000;
+
+    private const int OneKibiByte = 1024;
+    private const int OneMebiByte = 1024 * 1024;
+    private const int OneGibiByte = 1024 * 1024 * 1024;
+    private const long OneTebiByte = 1024L * 1024 * 1024 * 1024;
+
+    // ReSharper disable InconsistentNaming
+    public static long TB(this int tb) => tb.EnsurePositive() * OneTeraByte;
+    
+    public static int GB(this int gb) => gb.EnsurePositive() * OneGigaByte;
+
+    public static int MB(this int mb) => mb.EnsurePositive() * OneMegaByte;
+
+    public static int KB(this int kb) => kb.EnsurePositive() * OneKiloByte;
+
+    public static long TiB(this int tb) => tb.EnsurePositive() * OneTebiByte;
+
+    public static int GiB(this int gb) => gb.EnsurePositive() * OneGibiByte;
+
+    public static int MiB(this int mb) => mb.EnsurePositive() * OneMebiByte;
+
+    public static int KiB(this int kb) => kb.EnsurePositive() * OneKibiByte;
+    // ReSharper restore InconsistentNaming
+
+    public static string ToHumanReadable(this short size) => ((long)size.EnsurePositive()).ToHumanReadable();
+
+    public static string ToHumanReadable(this ushort size) => ((long)size.EnsurePositive()).ToHumanReadable();
+
+    public static string ToHumanReadable(this int size) => ((long)size.EnsurePositive()).ToHumanReadable();
+
+    public static string ToHumanReadable(this uint size) => ((long)size.EnsurePositive()).ToHumanReadable();
+
+    public static string ToHumanReadable(this long size) => ((ulong)size.EnsurePositive()).ToHumanReadable();
+
+    public static string ToHumanReadable(this ulong size)
+    {
+        switch (size)
+        {
+            case > OneTeraByte:
+                return $"{Math.Round((float)size / OneTebiByte, 1)} TB";
+            case > OneGigaByte:
+                return $"{Math.Round((float)size / OneGibiByte, 1)} GB";
+            case > OneMegaByte:
+                return $"{Math.Round((float)size / OneMebiByte, 1)} MB";
+            case > OneKiloByte:
+                return $"{Math.Round((float)size / OneKibiByte, 1)} KB";
+            default:
+                return $"{size} B";
+        }
+    }
+    
+    private static T EnsurePositive<T>(this T size) where T : struct, IComparable<T>
+    {
+        if (size.CompareTo(default) < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(size), size, "Size cannot be negative");
+        }
+
+        return size;
+    }
+}


### PR DESCRIPTION
Introduced `ByteEx` utility for consistent size conversions (e.g., KB to MB) and human-readable formatting. Added comprehensive unit tests to ensure reliability. Updated `.DotSettings` for dictionary support on binary prefixes.